### PR TITLE
Fix broken Star History chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1336,4 +1336,4 @@ To promote transparency and reproducibility, we provide the structured annotatio
 
 # Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=AgenticHealthAI/Awesome-AI-Agents-for-Healthcare&type=date&legend=top-left)](https://www.star-history.com/#AgenticHealthAI/Awesome-AI-Agents-for-Healthcare&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=AgenticHealthAI/Awesome-AI-Agents-for-Healthcare&type=date&legend=top-left)](https://star-history.dera.page/#AgenticHealthAI/Awesome-AI-Agents-for-Healthcare&type=date&legend=top-left)


### PR DESCRIPTION
The Star History chart embedded in the README currently fails to render due to the underlying service being broken under GitHub's stargazer API restrictions. This change points the chart at a working mirror that does not need an API token, restoring the project's star growth visualization so contributors and readers can see how the project is trending at a glance.

No other content was modified.